### PR TITLE
fix(style): unset min-width for video playing page

### DIFF
--- a/src/style/video.css
+++ b/src/style/video.css
@@ -13,6 +13,7 @@ body[scroll-hidden] {
 /* 主应用块 */
 #app {
     --sidebar-time: .6s;
+    min-width: auto !important; /* 覆盖原始 min-width: 1080px; */
 }
 
 /* 主体内容块 */


### PR DESCRIPTION
B站视频播放页`#app`新增了`min-width: 1080px;`的CSS样式，导致视频简介、评论等宽度溢出（见 #18 ），添加`min-width: auto !important;`以解决此问题。

另外 #18 中提到的空间页失效问题源于B站空间页改版，但是有“返回旧版”的选项目前也仍旧能用。适应新版几乎要重写`space.css`中的选择器，感觉工作量确实不小，目前B站改版已有半年，不知作者是否有添加新版空间支持的计划？